### PR TITLE
Remove redundant mentions of "for Emacs"

### DIFF
--- a/opensource.el
+++ b/opensource.el
@@ -1,4 +1,4 @@
-;;; opensource.el --- Emacs client for Opensource API
+;;; opensource.el --- Client for Opensource API
 
 ;; Author: Nicolas Lamirault <nicolas.lamirault@gmail.com>
 ;; URL: https://github.com/nlamirault/opensource.el
@@ -23,7 +23,7 @@
 
 ;;; Commentary:
 
-;; Provides an Opensource API client for Emacs.
+;; Provides an Opensource API client.
 
 ;;; Installation:
 
@@ -45,7 +45,7 @@
 ;; Customization
 
 (defgroup opensource nil
-  "Opensource API client for Emacs."
+  "Opensource API client."
   :group 'applications
   :link '(url-link :tag "Github" "https://github.com/nlamirault/opensource.el")
   :link '(emacs-commentary-link :tag "Commentary" "opensource API client"))


### PR DESCRIPTION
Any package installed in Emacs is for Emacs, so these mentions are redundant. (In connection with https://github.com/melpa/melpa/pull/3995)
